### PR TITLE
Improve mail transmission perf, invoice creation

### DIFF
--- a/barsys/forms.py
+++ b/barsys/forms.py
@@ -94,7 +94,8 @@ class InvoicesCreateForm(forms.Form):
     send_invoices = forms.BooleanField(required=False, initial=True,
                                        help_text="Whether to send invoice mails to the users' mail addresses. "
                                                  "Users who do not pay for themselves will get a notification of their "
-                                                 "purchases instead of a real invoice. "
+                                                 "purchases instead of a real invoice. If an error occurs during "
+                                                 "sending, new invoices may be deleted again automatically."
                                                  "If false, invoices will only be created internally.")
 
     send_dependant_notifications = forms.BooleanField(required=False, initial=True,

--- a/barsys/models.py
+++ b/barsys/models.py
@@ -128,7 +128,7 @@ class User(AbstractBaseUser):
                 raise ValidationError({'purchases_paid_by_other': "Purchases cannot be paid by someone who does not "
                                                                   "pay for their own purchases."})
             dependents = self.dependents()
-            if dependents.exists():
+            if self.pk is not None and dependents.exists():
                 other_names = [u.display_name for u in dependents]
                 raise ValidationError({'purchases_paid_by_other': "This user pays for the following users, so "
                                                                   "their purchases cannot be paid by someone else: {}"


### PR DESCRIPTION
Previously, pybarsys opened a new connection for each mail. With this change, it (for the most part) opens one connection and keeps that open for all mails.
This seems to improve perf by roughly 10x in some
simple tests, making it less frustrating to generate a lot of invoices.

If there is an error during mail tx, new invoices now are automatically deleted to not make it seem like they were delivered to the user.

There was a small validation bug which made it impossible to create a new user for which someone else has to pay in one go (how was this never a bug report?!).

Updated some dependency to make it compatible with recent Python versions. Actually, a lot more updates are needed...