### PR TITLE
Refactor mail sending and improve invoice/payment admin UX

### DIFF
--- a/barsys/forms.py
+++ b/barsys/forms.py
@@ -326,6 +326,10 @@ class PaymentForm(forms.ModelForm):
         model = Payment
         exclude = ('invoice',)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['user'].queryset = User.objects.filter(purchases_paid_by_other__isnull=True)
+
 
 class FreeItemForm(forms.ModelForm):
     class Meta:

--- a/barsys/forms.py
+++ b/barsys/forms.py
@@ -7,6 +7,7 @@ from django.contrib.auth import forms as auth_forms
 from django.utils.translation import ugettext_lazy as _
 
 from .models import *
+from pybarsys.settings import PybarsysPreferences
 
 
 class LoginForm(auth_forms.AuthenticationForm):
@@ -93,24 +94,25 @@ class InvoicesCreateForm(forms.Form):
 
     send_invoices = forms.BooleanField(required=False, initial=True,
                                        help_text="Whether to send invoice mails to the users' mail addresses. "
-                                                 "Users who do not pay for themselves will get a notification of their "
-                                                 "purchases instead of a real invoice. If an error occurs during "
-                                                 "sending, new invoices may be deleted again automatically."
+                                                 "If an error occurs during mail transmission, "
+                                                 "no invoice will be created."
                                                  "If false, invoices will only be created internally.")
 
     send_dependant_notifications = forms.BooleanField(required=False, initial=True,
                                                       help_text="Whether to send purchase notifications to users who do"
-                                                                " not pay themselves (only valid if invoices are sent "
-                                                                "at all).")
+                                                                " not pay themselves (only valid if invoice mails are "
+                                                                "sent at all).")
 
     send_payment_reminders = forms.BooleanField(required=False, initial=True,
                                                 help_text="Whether to send payment reminder mails to users with an "
                                                           "account balance below number defined in settings, but "
-                                                          "no unbilled purchases.")
+                                                          "no unbilled purchases (only valid if invoice mails are "
+                                                          "sent at all).")
 
     autolock_accounts = forms.BooleanField(required=False, initial=True,
                                            help_text="Automatically lock account if balance is below "
-                                                     "number defined in settings before and after creating new invoices.")
+                                                     "{} before and after creating new invoices.".format(
+                                                         currency(PybarsysPreferences.Misc.BALANCE_BELOW_AUTOLOCK)))
 
     comment = forms.CharField(label="Comment", required=False)
 

--- a/barsys/templates/barsys/admin/invoice_detail.html
+++ b/barsys/templates/barsys/admin/invoice_detail.html
@@ -72,4 +72,9 @@
             </tbody>
         </table>
     </div>
+    <p class="text-right">
+        <a href="{% url 'admin_invoice_mail' invoice.pk %}" class="btn btn-default btn-xs" target="_blank">
+            {% bootstrap_icon 'new-window' %} Open mail preview
+        </a>
+    </p>
 {% endblock %}

--- a/barsys/templates/barsys/admin/invoice_new.html
+++ b/barsys/templates/barsys/admin/invoice_new.html
@@ -6,4 +6,21 @@
 
     <h1>Create invoices</h1>
     {% crispy form %}
+    <script>
+        (function () {
+            var select = document.getElementById('id_users');
+            var input = document.createElement('input');
+            input.type = 'text';
+            input.placeholder = 'Filter by user name';
+            input.className = 'form-control';
+            input.style.marginBottom = '4px';
+            select.parentNode.insertBefore(input, select);
+            input.addEventListener('keyup', function () {
+                var q = input.value.toLowerCase();
+                Array.from(select.options).forEach(function (opt) {
+                    opt.style.display = opt.text.toLowerCase().includes(q) ? '' : 'none';
+                });
+            });
+        })();
+    </script>
 {% endblock %}

--- a/barsys/templates/barsys/admin/payment_detail.html
+++ b/barsys/templates/barsys/admin/payment_detail.html
@@ -53,4 +53,8 @@
 
         </tbody>
     </table>
+
+    <a href="{% url 'admin_invoice_new' %}?user={{ object.user_id }}" class="btn btn-primary btn-lg btn-block">
+        {% bootstrap_icon 'file' %} Generate invoice for {{ object.user }}
+    </a>
 {% endblock %}

--- a/barsys/templates/barsys/admin/user_detail.html
+++ b/barsys/templates/barsys/admin/user_detail.html
@@ -7,9 +7,16 @@
     <div>
         <h1 class="pull-left" style="margin-top: 0;">User details</h1>
         <div class="btn-group pull-right" role="group">
+            {% if object.pays_themselves %}
+            <a href="{% url 'admin_invoice_new' %}?user={{ object.pk }}" class="btn btn-default">
+                {% bootstrap_icon 'file' %} Create invoice
+            </a>
+            {% endif %}
+            {% if object.account_balance < 0 %}
             <a href="{% url 'admin_user_payment_reminder_send' object.pk %}" class="btn btn-warning">
                 {% bootstrap_icon 'warning-sign' %} Send payment reminder
             </a>
+            {% endif %}
             <a href="{% url 'admin_user_update' object.pk %}" class="btn btn-primary">
                 {% bootstrap_icon 'pencil' %} Change
             </a>
@@ -124,4 +131,9 @@
 
     <p>{{ invoices_page_obj.paginator.count }} result(s)</p>
     {% bootstrap_pagination invoices_page_obj extra=request.GET.urlencode parameter_name="invoices_page" %}
+    <p class="text-right">
+        <a href="{% url 'admin_user_payment_reminder_mail' object.pk %}" class="btn btn-default btn-xs" target="_blank">
+            {% bootstrap_icon 'new-window' %} Open payment reminder preview
+        </a>
+    </p>
 {% endblock %}

--- a/barsys/view_helpers.py
+++ b/barsys/view_helpers.py
@@ -172,101 +172,77 @@ def generate_email_purchase_notification(dependant: User, purchases: Iterable[Pu
     return msg
 
 
-def send_invoice_mails(request, invoices, users_autolocked: list[User], send_dependant_notifications: bool):
-    """ Send invoice mails to invoice recipients with a list of all purchases of that invoice.
-        Optionally send purchase notifications to users whose purchases are paid by someone else.
-    """
-    num_invoice_mail_success = 0
-    invoice_mail_failure = []  # [(username, error), ...]
 
-    num_purchase_notif_mail_success = 0
-    purchase_notif_mail_failure = []
-
-    # open connection only once to avoid repeated unnecessary connections for multiple mails
-    try:
-        conn = EmailConnectionWrapper(fake_sending_mails=False)
-    except Exception as e:
-        for invoice in invoices:
-            invoice.delete()
-        for user in users_autolocked:
-            user.is_autolocked = False
-            user.save()
-        messages.error(request, "Deleted new invoices and undid autolocks because connection to mail server could not be "
-                                "established: {}".format(e))
-        return
-
-    MAIL_CONNECTION_FAILURE_COUNT_LIMIT = 4
-    for invoice in invoices:
-        # first, check whether we already had too many failures sending mails. If yes, just delete the remaining invoices
-        if conn.error_count >= MAIL_CONNECTION_FAILURE_COUNT_LIMIT:
-            invoice.delete()
-            if invoice.recipient.is_autolocked and invoice.recipient in users_autolocked:
-                # Recipient was autolocked through this invoice
-                invoice.recipient.is_autolocked = False
-                invoice.recipient.save()
-            if conn.error_count == MAIL_CONNECTION_FAILURE_COUNT_LIMIT:
-                messages.error(request,
-                               "Too many errors during mail transmission - "
-                               "deleted all remaining, unsent invoices and undid autolocks")
-            conn.error_count += 1  # keep incrementing so the == check above fires only once
-            continue
-
-        if not conn.send_message(generate_email_invoice(invoice)):
-            invoice_mail_failure.append((invoice.recipient, conn.last_error))
-            invoice.delete()
-            if invoice.recipient.is_autolocked and invoice.recipient in users_autolocked:
-                # Recipient was autolocked through this invoice
-                invoice.recipient.is_autolocked = False
-                invoice.recipient.save()
-            continue
-        num_invoice_mail_success += 1
-
-        if send_dependant_notifications and invoice.has_dependant_purchases():
-            # send purchase notifications to dependants
-            for dependant, purchases in invoice.other_purchases_grouped():
-                if not conn.send_message(generate_email_purchase_notification(dependant, purchases, invoice)):
-                    purchase_notif_mail_failure.append((dependant, conn.last_error))
-                    # do not delete invoice due to this, but count as error
-                else:
-                    num_purchase_notif_mail_success += 1
-
-    conn.close()
-
-    if num_invoice_mail_success > 0:
-        messages.info(request, "{} invoice mails were successfully sent. ".format(num_invoice_mail_success))
-    if len(invoice_mail_failure) > 0:
-        messages.error(request,
-                       "Sending invoice mail(s) to the following user(s) failed, deleted the invoice again and "
-                       "undid potential autolock: {}".
-                       format(", ".join(["{} ({})".format(u, err) for u, err in invoice_mail_failure])))
-
-    if num_purchase_notif_mail_success > 0:
-        messages.info(request, "{} dependant notification mails were successfully sent. ".format(
-            num_purchase_notif_mail_success))
-    if len(purchase_notif_mail_failure) > 0:
-        messages.error(request, "Sending dependant notification mail(s) to the following user(s) failed: {}".
-                       format(", ".join(["{} ({})".format(u, err) for u, err in purchase_notif_mail_failure])))
-
-
-def create_invoices(request, users: list[User], send_invoices: bool = True, send_dependant_notifications: bool = True,
-                    send_payment_reminders: bool = True, autolock_accounts: bool = True, comment: str = "") -> list:
+def create_invoices(request, users: list[User], send_mails: bool, send_dependant_notifications: bool,
+                    send_payment_reminders: bool, autolock_accounts: bool, comment: str = "") -> list[Invoice]:
     """Create invoices for users, send mails, handle autolocking. Returns list of created Invoice objects."""
-    skipped_users = []
     invoices = []
-    users_to_remind = []
     users_autolocked: list[User] = []
     users_autounlocked: list[User] = []
 
+    # Only send these if we also want to send mails at all
+    send_dependant_notifications = send_mails and send_dependant_notifications
+    send_payment_reminders = send_mails and send_payment_reminders
+
+    num_invoice_mail_success = 0
+    invoice_mail_failure: list[tuple[User, Exception]] = []
+
+    num_reminder_mail_success = 0
+    reminder_mail_failure: list[tuple[User, Exception]] = []
+
+    # for dependants
+    num_purchase_notif_mail_success = 0
+    purchase_notif_mail_failure: list[tuple[User, Exception]] = []
+
+    # open connection only once to avoid repeated unnecessary connections for multiple mails
+    # fake opening the connection if we do not want to send any emails (to keep the logic the same as when we do)
+    try:
+        conn = EmailConnectionWrapper(fake_sending_mails=not send_mails)
+    except Exception as e:
+        messages.error(request,
+                       "No invoice(s) created because connection to mail server could not be "
+                       "established: {}".format(e))
+        return invoices
+
+    MAIL_CONNECTION_FAILURE_COUNT_LIMIT = 4
+
     for user in users:
+        if conn.error_count >= MAIL_CONNECTION_FAILURE_COUNT_LIMIT:
+            messages.error(request,
+                           "Too many errors during mail transmission - "
+                           "stopped invoice creation process early")
+            break
+
         balance_before = user.account_balance()
 
         if Purchase.objects.to_pay_by(user).exists() or user.payments().unbilled().exists():
+            # create and send invoice
             invoice = Invoice.objects.create_for_user(user, comment)
-            invoices.append(invoice)
+            if conn.send_message(generate_email_invoice(invoice)):
+                num_invoice_mail_success += 1
+                invoices.append(invoice)
+
+                # check whether dependants need to get purchase notifications
+                if send_dependant_notifications and invoice.has_dependant_purchases():
+                    # send purchase notifications to dependants
+                    for dependant, purchases in invoice.other_purchases_grouped():
+                        if conn.send_message(generate_email_purchase_notification(dependant, purchases, invoice)):
+                            num_purchase_notif_mail_success += 1
+                        else:
+                            purchase_notif_mail_failure.append((dependant, conn.last_error))
+                            # do not delete invoice due to this, but count as error
+            else:
+                invoice_mail_failure.append((invoice.recipient, conn.last_error))
+                invoice.delete()  # do not locally create an invoice if mail tx failed
+                continue
         else:
+            # no new invoice needed -> check whether payment reminder is needed
             if send_payment_reminders and user.account_balance() < PybarsysPreferences.Misc.BALANCE_BELOW_TRANSFER_MONEY:
-                users_to_remind.append(user)
-            skipped_users.append(user)
+                # send payment reminder
+                if conn.send_message(generate_email_payment_reminder(user)):
+                    num_reminder_mail_success += 1
+                else:
+                    reminder_mail_failure.append((user, conn.last_error))
 
         if user.is_autolocked and user.account_balance() > PybarsysPreferences.Misc.BALANCE_BELOW_AUTOLOCK:
             user.is_autolocked = False
@@ -276,19 +252,17 @@ def create_invoices(request, users: list[User], send_invoices: bool = True, send
         if autolock_accounts and not user.is_autolocked:
             if (balance_before < PybarsysPreferences.Misc.BALANCE_BELOW_AUTOLOCK and
                     user.account_balance() < PybarsysPreferences.Misc.BALANCE_BELOW_AUTOLOCK):
+                # autolock is needed
                 user.is_autolocked = True
                 user.save()
                 users_autolocked.append(user)
 
     if len(invoices) > 0:
-        created_str = "Created {} invoice(s) for: {}.".format(len(invoices), ", ".join(
-            [i.recipient.display_name for i in invoices]))
+        messages.success(request, "Created {} invoice(s) for: {}.".format(len(invoices),
+                                                                 ", ".join(
+            [i.recipient.display_name for i in invoices])))
     else:
-        created_str = "No invoices were created."
-    messages.info(request, created_str)
-
-    if len(skipped_users) > 0:
-        messages.info(request, "Skipped {} user(s) because they did not need new invoices.".format(len(skipped_users)))
+        messages.info(request, "No invoices were created.")
 
     if len(users_autolocked) > 0:
         messages.warning(request, "The following users were autolocked: {}".format(
@@ -298,15 +272,30 @@ def create_invoices(request, users: list[User], send_invoices: bool = True, send
         messages.success(request, "The following users were auto-unlocked: {}".format(
             ', '.join([str(u) for u in users_autounlocked])))
 
-    if send_invoices and len(invoices) > 0:
-        # WARNING: This call may actually delete invoices or unlock users again if mails cannot be sent.
-        send_invoice_mails(request, invoices, users_autolocked,
-                           send_dependant_notifications=send_dependant_notifications)
-    else:
-        messages.info(request, "No invoice mails were sent.")
+    if send_mails:
+        if num_invoice_mail_success > 0:
+            messages.info(request, f"Sent {num_invoice_mail_success} invoice mails")
+        if len(invoice_mail_failure) > 0:
+            messages.error(request,
+                           "Sending invoice mail(s) to the following user(s) failed - no invoices were created: {}".
+                           format(", ".join(["{} ({})".format(u, err) for u, err in invoice_mail_failure])))
 
-    if len(users_to_remind) > 0:
-        send_reminder_mails(request, users_to_remind)
+    if send_dependant_notifications:
+        if num_purchase_notif_mail_success > 0:
+            messages.info(request, "{} dependant notification mails were successfully sent. ".format(
+                num_purchase_notif_mail_success))
+        if len(purchase_notif_mail_failure) > 0:
+            messages.error(request, "Sending dependant notification mail(s) to the following user(s) failed: {}".
+                           format(", ".join(["{} ({})".format(u, err) for u, err in purchase_notif_mail_failure])))
+
+    if send_payment_reminders:
+        if num_reminder_mail_success > 0:
+            messages.info(request, "{} payment reminders were successfully sent. ".format(num_reminder_mail_success))
+        if len(reminder_mail_failure) > 0:
+            messages.error(request, "Sending payment reminder mail(s) to the following user(s) failed: {}". \
+                           format(", ".join(["{} ({})".format(u, err) for u, err in reminder_mail_failure])))
+
+    conn.close()
 
     return invoices
 
@@ -332,49 +321,6 @@ def generate_email_payment_reminder(user: User) -> EmailMultiAlternatives:
     msg.attach_alternative(content_html, "text/html")
 
     return msg
-
-
-def send_reminder_mails(request, users):
-    """ Send payment reminder mails to users """
-    num_reminder_mail_success = 0
-    num_reminder_mail_skipped = 0
-    reminder_mail_failure = []  # [(username, error), ...]
-
-    # open connection only once to avoid repeated unnecessary connections for multiple mails
-    try:
-        conn = EmailConnectionWrapper(fake_sending_mails=False)
-    except Exception as e:
-        messages.error(request, "Did not send payment reminders because connection to mail server could not be "
-                                "established: {}".format(e))
-        return
-
-    MAIL_CONNECTION_FAILURE_COUNT_LIMIT = 4
-    for user in users:
-        # first, check whether we already had too many failures sending mails. If yes, just abort
-        if conn.error_count >= MAIL_CONNECTION_FAILURE_COUNT_LIMIT:
-            messages.error(request,
-                           "Too many errors during mail transmission - stopped sending payment reminders")
-            return
-
-        if user.account_balance() >= 0:
-            num_reminder_mail_skipped += 1
-            continue
-
-        if not conn.send_message(generate_email_payment_reminder(user)):
-            reminder_mail_failure.append((user, conn.last_error))
-        else:
-            num_reminder_mail_success += 1
-    conn.close()
-
-    if num_reminder_mail_success > 0:
-        messages.info(request, "{} payment reminders were successfully sent. ".format(num_reminder_mail_success))
-    if num_reminder_mail_skipped > 0:
-        messages.info(request,
-                      "{} payment reminder(s) skipped: account balance not below 0.".format(
-                          num_reminder_mail_skipped))
-    if len(reminder_mail_failure) > 0:
-        messages.error(request, "Sending payment reminder mail(s) to the following user(s) failed: {}". \
-                       format(", ".join(["{} ({})".format(u, err) for u, err in reminder_mail_failure])))
 
 
 def group_users(ungrouped_users):

--- a/barsys/view_helpers.py
+++ b/barsys/view_helpers.py
@@ -1,6 +1,7 @@
 import os.path
 from collections import OrderedDict
 from itertools import groupby
+from typing import Iterable, Optional
 
 from django.contrib import messages
 from django.core import mail
@@ -11,7 +12,7 @@ from django.utils import timezone
 
 from pybarsys import settings as pybarsys_settings
 from pybarsys.settings import PybarsysPreferences
-from .models import StatsDisplay, Purchase, Invoice, Product
+from .models import StatsDisplay, Purchase, Invoice, Product, User
 
 
 def get_renderable_stats_elements():
@@ -78,7 +79,100 @@ def get_renderable_stats_elements():
     return stats_elements
 
 
-def send_invoice_mails(request, invoices, send_dependant_notifications=False):
+class EmailConnectionWrapper:
+    """Wraps a Django mail connection with error-safe bool-returning send_message().
+
+    This can also be used to simulate sending a mail when that may not be wanted due to preferences.
+    """
+
+    def __init__(self, fake_sending_mails: bool) -> None:
+        """Open the mail connection. Raises on connection failure.
+
+        Args:
+            fake_sending_mails: If True, simulate success without actually sending any mail.
+        """
+        self.fake_sending_mails = fake_sending_mails
+        self.last_error: Optional[Exception] = None
+        self.error_count: int = 0  # incremented on each failed send_message() call
+        self._connection = None
+        if not fake_sending_mails:
+            self._connection = mail.get_connection(fail_silently=False)
+            self._connection.open()  # may raise
+
+    def send_message(self, msg: EmailMultiAlternatives) -> bool:
+        """Send a single message. Returns True on success, False on failure.
+
+        Note: Django's send_messages() returns an int (number of messages sent);
+        this wrapper returns bool instead.
+        """
+        if self.fake_sending_mails:
+            return True
+        try:
+            self._connection.send_messages((msg,))
+            return True
+        except Exception as e:
+            self.last_error = e
+            self.error_count += 1
+            return False
+
+    def close(self) -> None:
+        """Close the mail connection."""
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None
+
+    def __del__(self) -> None:
+        self.close()
+
+
+def generate_email_invoice(invoice: Invoice) -> EmailMultiAlternatives:
+    """Generate invoice mail for a normal, paying user."""
+    context = {}
+    context["pybarsys_preferences"] = PybarsysPreferences
+    context["subject"] = PybarsysPreferences.EMAIL.INVOICE_SUBJECT
+    context["invoice"] = invoice
+    context["recipient"] = invoice.recipient
+    context["own_purchases"] = invoice.own_purchases()
+    context["other_purchases_grouped"] = invoice.other_purchases_grouped()
+    context["last_invoices"] = invoice.recipient.invoices()[:5]
+    context["payments"] = invoice.payments()
+
+    content_plain = render_to_string(
+        os.path.join(PybarsysPreferences.EMAIL.TEMPLATE_DIR, "normal_invoice.plaintext.html"
+                     ), context)
+    content_html = render_to_string(
+        os.path.join(PybarsysPreferences.EMAIL.TEMPLATE_DIR, "normal_invoice.html.html"),
+        context)
+    msg = EmailMultiAlternatives(PybarsysPreferences.EMAIL.INVOICE_SUBJECT, content_plain,
+                                 pybarsys_settings.EMAIL_FROM_ADDRESS, [invoice.recipient.email],
+                                 reply_to=[PybarsysPreferences.EMAIL.CONTACT_EMAIL])
+    msg.attach_alternative(content_html, "text/html")
+
+    return msg
+
+
+def generate_email_purchase_notification(dependant: User, purchases: Iterable[Purchase],
+                                         invoice: Invoice) -> EmailMultiAlternatives:
+    """Generate purchase notification mail for a dependant."""
+    notif_context = {}
+    notif_context["pybarsys_preferences"] = PybarsysPreferences
+    notif_context["subject"] = PybarsysPreferences.EMAIL.PURCHASE_NOTIFICATION_SUBJECT
+    notif_context["invoice"] = invoice
+    notif_context["dependant"] = dependant
+    notif_context["purchases"] = purchases
+    content_plain = render_to_string(os.path.join(PybarsysPreferences.EMAIL.TEMPLATE_DIR,
+                                                  "dependant_notification.plaintext.html"), notif_context)
+    content_html = render_to_string(os.path.join(PybarsysPreferences.EMAIL.TEMPLATE_DIR,
+                                                 "dependant_notification.html.html"), notif_context)
+    msg = EmailMultiAlternatives(PybarsysPreferences.EMAIL.PURCHASE_NOTIFICATION_SUBJECT, content_plain,
+                                 pybarsys_settings.EMAIL_FROM_ADDRESS, [dependant.email],
+                                 reply_to=[PybarsysPreferences.EMAIL.CONTACT_EMAIL])
+    msg.attach_alternative(content_html, "text/html")
+
+    return msg
+
+
+def send_invoice_mails(request, invoices, users_autolocked: list[User], send_dependant_notifications: bool):
     """ Send invoice mails to invoice recipients with a list of all purchases of that invoice.
         Optionally send purchase notifications to users whose purchases are paid by someone else.
     """
@@ -90,86 +184,60 @@ def send_invoice_mails(request, invoices, send_dependant_notifications=False):
 
     # open connection only once to avoid repeated unnecessary connections for multiple mails
     try:
-        mail_connection = mail.get_connection(fail_silently=False)
-        mail_connection.open()
-        mail_connection_error_count = 0 # keep track or errors below and abort after a few
+        conn = EmailConnectionWrapper(fake_sending_mails=False)
     except Exception as e:
         for invoice in invoices:
             invoice.delete()
-        messages.error(request, "Deleted new invoices because connection to mail server could not be "
+        for user in users_autolocked:
+            user.is_autolocked = False
+            user.save()
+        messages.error(request, "Deleted new invoices and undid autolocks because connection to mail server could not be "
                                 "established: {}".format(e))
         return
 
+    MAIL_CONNECTION_FAILURE_COUNT_LIMIT = 4
     for invoice in invoices:
         # first, check whether we already had too many failures sending mails. If yes, just delete the remaining invoices
-        MAIL_CONNECTION_FAILURE_COUNT_LIMIT = 4
-        if mail_connection_error_count >= MAIL_CONNECTION_FAILURE_COUNT_LIMIT:
+        if conn.error_count >= MAIL_CONNECTION_FAILURE_COUNT_LIMIT:
             invoice.delete()
-            if mail_connection_error_count == MAIL_CONNECTION_FAILURE_COUNT_LIMIT:
+            if invoice.recipient.is_autolocked and invoice.recipient in users_autolocked:
+                # Recipient was autolocked through this invoice
+                invoice.recipient.is_autolocked = False
+                invoice.recipient.save()
+            if conn.error_count == MAIL_CONNECTION_FAILURE_COUNT_LIMIT:
                 messages.error(request,
-                               "Too many errors during mail transmission - deleted all remaining, unsent invoices")
-            mail_connection_error_count += 1
+                               "Too many errors during mail transmission - "
+                               "deleted all remaining, unsent invoices and undid autolocks")
+            conn.error_count += 1  # keep incrementing so the == check above fires only once
             continue
 
-        context = {}
-        context["pybarsys_preferences"] = PybarsysPreferences
-        context["invoice"] = invoice
-        context["recipient"] = invoice.recipient
-        context["own_purchases"] = invoice.own_purchases()
-        context["other_purchases_grouped"] = invoice.other_purchases_grouped()
-        context["last_invoices"] = invoice.recipient.invoices()[:5]
-        context["payments"] = invoice.payments()
-
-        content_plain = render_to_string(
-            os.path.join(PybarsysPreferences.EMAIL.TEMPLATE_DIR, "normal_invoice.plaintext.html"
-                         ), context)
-        content_html = render_to_string(
-            os.path.join(PybarsysPreferences.EMAIL.TEMPLATE_DIR, "normal_invoice.html.html"),
-            context)
-        msg = EmailMultiAlternatives(PybarsysPreferences.EMAIL.INVOICE_SUBJECT, content_plain,
-                                     pybarsys_settings.EMAIL_FROM_ADDRESS, [invoice.recipient.email],
-                                     reply_to=[PybarsysPreferences.EMAIL.CONTACT_EMAIL])
-        msg.attach_alternative(content_html, "text/html")
-        try:
-            mail_connection.send_messages((msg, ))
-            num_invoice_mail_success += 1
-        except Exception as e:
-            invoice_mail_failure.append((invoice.recipient, e))
+        if not conn.send_message(generate_email_invoice(invoice)):
+            invoice_mail_failure.append((invoice.recipient, conn.last_error))
             invoice.delete()
-            mail_connection_error_count += 1
+            if invoice.recipient.is_autolocked and invoice.recipient in users_autolocked:
+                # Recipient was autolocked through this invoice
+                invoice.recipient.is_autolocked = False
+                invoice.recipient.save()
             continue
+        num_invoice_mail_success += 1
 
         if send_dependant_notifications and invoice.has_dependant_purchases():
             # send purchase notifications to dependants
             for dependant, purchases in invoice.other_purchases_grouped():
-                notif_context = {}
-                notif_context["pybarsys_preferences"] = PybarsysPreferences
-                notif_context["invoice"] = invoice
-                notif_context["dependant"] = dependant
-                notif_context["purchases"] = purchases
-                content_plain = render_to_string(os.path.join(PybarsysPreferences.EMAIL.TEMPLATE_DIR,
-                                                              "dependant_notification.plaintext.html"), notif_context)
-                content_html = render_to_string(os.path.join(PybarsysPreferences.EMAIL.TEMPLATE_DIR,
-                                                             "dependant_notification.html.html"), notif_context)
-                msg = EmailMultiAlternatives(PybarsysPreferences.EMAIL.PURCHASE_NOTIFICATION_SUBJECT, content_plain,
-                                             pybarsys_settings.EMAIL_FROM_ADDRESS, [dependant.email],
-                                             reply_to=[PybarsysPreferences.EMAIL.CONTACT_EMAIL])
-                msg.attach_alternative(content_html, "text/html")
-                try:
-                    mail_connection.send_messages((msg,))
-                    num_purchase_notif_mail_success += 1
-                except Exception as e:
-                    purchase_notif_mail_failure.append((dependant, e))
+                if not conn.send_message(generate_email_purchase_notification(dependant, purchases, invoice)):
+                    purchase_notif_mail_failure.append((dependant, conn.last_error))
                     # do not delete invoice due to this, but count as error
-                    mail_connection_error_count += 1
+                else:
+                    num_purchase_notif_mail_success += 1
 
-    mail_connection.close()
+    conn.close()
 
     if num_invoice_mail_success > 0:
         messages.info(request, "{} invoice mails were successfully sent. ".format(num_invoice_mail_success))
     if len(invoice_mail_failure) > 0:
         messages.error(request,
-                       "Sending invoice mail(s) to the following user(s) failed, deleted the invoice again: {}".
+                       "Sending invoice mail(s) to the following user(s) failed, deleted the invoice again and "
+                       "undid potential autolock: {}".
                        format(", ".join(["{} ({})".format(u, err) for u, err in invoice_mail_failure])))
 
     if num_purchase_notif_mail_success > 0:
@@ -180,55 +248,130 @@ def send_invoice_mails(request, invoices, send_dependant_notifications=False):
                        format(", ".join(["{} ({})".format(u, err) for u, err in purchase_notif_mail_failure])))
 
 
+def create_invoices(request, users: list[User], send_invoices: bool = True, send_dependant_notifications: bool = True,
+                    send_payment_reminders: bool = True, autolock_accounts: bool = True, comment: str = "") -> list:
+    """Create invoices for users, send mails, handle autolocking. Returns list of created Invoice objects."""
+    skipped_users = []
+    invoices = []
+    users_to_remind = []
+    users_autolocked: list[User] = []
+    users_autounlocked: list[User] = []
+
+    for user in users:
+        balance_before = user.account_balance()
+
+        if Purchase.objects.to_pay_by(user).exists() or user.payments().unbilled().exists():
+            invoice = Invoice.objects.create_for_user(user, comment)
+            invoices.append(invoice)
+        else:
+            if send_payment_reminders and user.account_balance() < PybarsysPreferences.Misc.BALANCE_BELOW_TRANSFER_MONEY:
+                users_to_remind.append(user)
+            skipped_users.append(user)
+
+        if user.is_autolocked and user.account_balance() > PybarsysPreferences.Misc.BALANCE_BELOW_AUTOLOCK:
+            user.is_autolocked = False
+            user.save()
+            users_autounlocked.append(user)
+
+        if autolock_accounts and not user.is_autolocked:
+            if (balance_before < PybarsysPreferences.Misc.BALANCE_BELOW_AUTOLOCK and
+                    user.account_balance() < PybarsysPreferences.Misc.BALANCE_BELOW_AUTOLOCK):
+                user.is_autolocked = True
+                user.save()
+                users_autolocked.append(user)
+
+    if len(invoices) > 0:
+        created_str = "Created {} invoice(s) for: {}.".format(len(invoices), ", ".join(
+            [i.recipient.display_name for i in invoices]))
+    else:
+        created_str = "No invoices were created."
+    messages.info(request, created_str)
+
+    if len(skipped_users) > 0:
+        messages.info(request, "Skipped {} user(s) because they did not need new invoices.".format(len(skipped_users)))
+
+    if len(users_autolocked) > 0:
+        messages.warning(request, "The following users were autolocked: {}".format(
+            ', '.join([str(u) for u in users_autolocked])))
+
+    if len(users_autounlocked) > 0:
+        messages.success(request, "The following users were auto-unlocked: {}".format(
+            ', '.join([str(u) for u in users_autounlocked])))
+
+    if send_invoices and len(invoices) > 0:
+        # WARNING: This call may actually delete invoices or unlock users again if mails cannot be sent.
+        send_invoice_mails(request, invoices, users_autolocked,
+                           send_dependant_notifications=send_dependant_notifications)
+    else:
+        messages.info(request, "No invoice mails were sent.")
+
+    if len(users_to_remind) > 0:
+        send_reminder_mails(request, users_to_remind)
+
+    return invoices
+
+
+def generate_email_payment_reminder(user: User) -> EmailMultiAlternatives:
+    """ Generate an email to be sent to a normal, paying user who does not have a new invoice """
+    context = {}
+    context["pybarsys_preferences"] = PybarsysPreferences
+    context["subject"] = PybarsysPreferences.EMAIL.PAYMENT_REMINDER_SUBJECT
+    context["user"] = user
+    context["recipient"] = user
+    context["last_invoices"] = user.invoices()[:5]
+    context["last_payments"] = user.payments()[:5]
+    content_plain = render_to_string(
+        os.path.join(PybarsysPreferences.EMAIL.TEMPLATE_DIR, "payment_reminder.plaintext.html"),
+        context)
+    content_html = render_to_string(
+        os.path.join(PybarsysPreferences.EMAIL.TEMPLATE_DIR, "payment_reminder.html.html"),
+        context)
+    msg = EmailMultiAlternatives(PybarsysPreferences.EMAIL.PAYMENT_REMINDER_SUBJECT, content_plain,
+                                 pybarsys_settings.EMAIL_FROM_ADDRESS, [user.email],
+                                 reply_to=[PybarsysPreferences.EMAIL.CONTACT_EMAIL])
+    msg.attach_alternative(content_html, "text/html")
+
+    return msg
+
+
 def send_reminder_mails(request, users):
     """ Send payment reminder mails to users """
     num_reminder_mail_success = 0
+    num_reminder_mail_skipped = 0
     reminder_mail_failure = []  # [(username, error), ...]
 
     # open connection only once to avoid repeated unnecessary connections for multiple mails
     try:
-        mail_connection = mail.get_connection(fail_silently=False)
-        mail_connection.open()
-        mail_connection_error_count = 0  # keep track or errors below and abort after a few
+        conn = EmailConnectionWrapper(fake_sending_mails=False)
     except Exception as e:
         messages.error(request, "Did not send payment reminders because connection to mail server could not be "
                                 "established: {}".format(e))
         return
 
+    MAIL_CONNECTION_FAILURE_COUNT_LIMIT = 4
     for user in users:
         # first, check whether we already had too many failures sending mails. If yes, just abort
-        MAIL_CONNECTION_FAILURE_COUNT_LIMIT = 4
-        if mail_connection_error_count >= MAIL_CONNECTION_FAILURE_COUNT_LIMIT:
+        if conn.error_count >= MAIL_CONNECTION_FAILURE_COUNT_LIMIT:
             messages.error(request,
                            "Too many errors during mail transmission - stopped sending payment reminders")
             return
 
-        context = {}
-        context["pybarsys_preferences"] = PybarsysPreferences
-        context["user"] = user
-        context["recipient"] = user
-        context["last_invoices"] = user.invoices()[:5]
-        context["last_payments"] = user.payments()[:5]
-        content_plain = render_to_string(
-            os.path.join(PybarsysPreferences.EMAIL.TEMPLATE_DIR, "payment_reminder.plaintext.html"),
-            context)
-        content_html = render_to_string(
-            os.path.join(PybarsysPreferences.EMAIL.TEMPLATE_DIR, "payment_reminder.html.html"),
-            context)
-        msg = EmailMultiAlternatives(PybarsysPreferences.EMAIL.PAYMENT_REMINDER_SUBJECT, content_plain,
-                                     pybarsys_settings.EMAIL_FROM_ADDRESS, [user.email],
-                                     reply_to=[PybarsysPreferences.EMAIL.CONTACT_EMAIL])
-        msg.attach_alternative(content_html, "text/html")
-        try:
-            mail_connection.send_messages((msg,))
+        if user.account_balance() >= 0:
+            num_reminder_mail_skipped += 1
+            continue
+
+        if not conn.send_message(generate_email_payment_reminder(user)):
+            reminder_mail_failure.append((user, conn.last_error))
+        else:
             num_reminder_mail_success += 1
-        except Exception as e:
-            reminder_mail_failure.append((user, e))
-            mail_connection_error_count += 1
-    mail_connection.close()
+    conn.close()
 
     if num_reminder_mail_success > 0:
         messages.info(request, "{} payment reminders were successfully sent. ".format(num_reminder_mail_success))
+    if num_reminder_mail_skipped > 0:
+        messages.info(request,
+                      "{} payment reminder(s) skipped: account balance not below 0.".format(
+                          num_reminder_mail_skipped))
     if len(reminder_mail_failure) > 0:
         messages.error(request, "Sending payment reminder mail(s) to the following user(s) failed: {}". \
                        format(", ".join(["{} ({})".format(u, err) for u, err in reminder_mail_failure])))

--- a/barsys/views.py
+++ b/barsys/views.py
@@ -347,6 +347,16 @@ class PaymentCreateView(UserIsAdminMixin, edit.CreateView):
     form_class = PaymentForm
     template_name = "barsys/admin/payment_new.html"
 
+    def form_valid(self, form):
+        user = form.cleaned_data['user']
+        if not user.pays_themselves():
+            messages.error(self.request,
+                           "Cannot add payment for {}: purchases are paid by {}.".format(
+                               user, user.purchases_paid_by_other))
+            return redirect('admin_payment_new')
+        return super().form_valid(form)
+
+
 
 class PaymentUpdateView(UserIsAdminMixin, edit.UpdateView):
     model = Payment
@@ -398,7 +408,7 @@ class InvoiceDetailView(UserIsAdminMixin, DetailView):
 class InvoiceResendView(UserIsAdminMixin, View):
     def get(self, request, pk):
         invoice = get_object_or_404(Invoice, pk=pk)
-        view_helpers.send_invoice_mails(request, [invoice])
+        view_helpers.send_invoice_mails(request, [invoice], users_autolocked=[], send_dependant_notifications=True)
         return redirect("admin_invoice_list")
 
 
@@ -423,6 +433,7 @@ class InvoiceMailDebugView(UserIsAdminMixin, DetailView):
         context["invoice"] = invoice
         context["recipient"] = invoice.recipient
         context["pybarsys_preferences"] = PybarsysPreferences
+        context["subject"] = PybarsysPreferences.EMAIL.INVOICE_SUBJECT
         context["own_purchases"] = invoice.own_purchases()
         context["other_purchases_grouped"] = invoice.other_purchases_grouped()
         context["last_invoices"] = invoice.recipient.invoices()[:5]
@@ -442,6 +453,7 @@ class PaymentReminderMailDebugView(UserIsAdminMixin, DetailView):
 
         context["recipient"] = user
         context["pybarsys_preferences"] = PybarsysPreferences
+        context["subject"] = PybarsysPreferences.EMAIL.PAYMENT_REMINDER_SUBJECT
         context["last_invoices"] = user.invoices()[:5]
         context["last_payments"] = user.payments()[:5]
 
@@ -456,77 +468,25 @@ class InvoiceCreateView(UserIsAdminMixin, edit.FormView):
     form_class = InvoicesCreateForm
     success_url = reverse_lazy("admin_invoice_list")
 
+    def get_initial(self):
+        initial = super().get_initial()
+        user_pk = self.request.GET.get('user')
+        if user_pk:
+            initial['users'] = [user_pk]
+        return initial
+
     def form_valid(self, form):
-        users = form.cleaned_data["users"]
-        send_invoices = form.cleaned_data["send_invoices"]
-        send_dependant_notifications = form.cleaned_data["send_dependant_notifications"]
-        send_payment_reminders = form.cleaned_data["send_payment_reminders"]
-        autolock_accounts = form.cleaned_data["autolock_accounts"]
-        comment = form.cleaned_data["comment"]
-
-        skipped_users = []
-        invoices = []
-        users_to_remind = []
-        users_autolocked = []
-
-        for user in users:
-
-            balance_before = user.account_balance()
-
-            if Purchase.objects.to_pay_by(user).exists() or user.payments().unbilled().exists():
-                # print("{} has {} purchases to pay for: ".format(user, purchases_to_pay.count()))
-                invoice = Invoice.objects.create_for_user(user, comment)
-                invoices.append(invoice)
-            else:
-                # print("{} has no purchases to pay for".format(user))
-                if send_payment_reminders and user.account_balance() < PybarsysPreferences.Misc.BALANCE_BELOW_TRANSFER_MONEY:
-                    users_to_remind.append(user)
-                skipped_users.append(user)
-
-            # remove autolock if new balance is adequate
-            if user.is_autolocked and user.account_balance() > PybarsysPreferences.Misc.BALANCE_BELOW_AUTOLOCK:
-                user.is_autolocked = False
-                user.save()
-
-            if autolock_accounts:
-                # autolock user if necessary
-                if balance_before < PybarsysPreferences.Misc.BALANCE_BELOW_AUTOLOCK and user.account_balance() < PybarsysPreferences.Misc.BALANCE_BELOW_AUTOLOCK:
-                    # user has surpassed autolock threshold twice
-                    user.is_autolocked = True
-                    user.save()
-                    users_autolocked.append(user)
-
-        if len(invoices) > 0:
-            created_str = "Created {} invoice(s) for the following user(s): {}. ".format(len(invoices), ", ".join(
-                ["{} ({})".format(i.recipient.display_name, currency(i.amount_purchases - i.amount_payments)) for i in
-                 invoices]))
-        else:
-            created_str = "No invoices were created. "
-        messages.info(self.request, created_str)
-
-        if len(skipped_users) > 0:
-            # skipped_str = "Skipped {} user(s): {}".format(len(skipped_users), ' ,'.join([u.__str__() for u in skipped_users]))
-            skipped_str = "Skipped {} user(s) because they did not need new invoices.".format(len(skipped_users))
-            messages.info(self.request, skipped_str)
-
-        if len(users_autolocked) > 0:
-            autolocked_str = "The following users were autolocked: {}".format(
-                ', '.join([u.__str__() for u in users_autolocked])
-            )
-            messages.warning(self.request, autolocked_str)
-
-        # Send invoice mails if wanted
-        if send_invoices and len(invoices) > 0:
-            view_helpers.send_invoice_mails(self.request, invoices,
-                                            send_dependant_notifications=send_dependant_notifications)
-        else:
-            messages.info(self.request, "No invoice mails were sent.")
-
-        # Send payment reminder mails
-        if len(users_to_remind) > 0:
-            view_helpers.send_reminder_mails(self.request, users_to_remind)
-
+        view_helpers.create_invoices(
+            self.request,
+            users=form.cleaned_data["users"],
+            send_invoices=form.cleaned_data["send_invoices"],
+            send_dependant_notifications=form.cleaned_data["send_dependant_notifications"],
+            send_payment_reminders=form.cleaned_data["send_payment_reminders"],
+            autolock_accounts=form.cleaned_data["autolock_accounts"],
+            comment=form.cleaned_data["comment"],
+        )
         return super(InvoiceCreateView, self).form_valid(form)
+
 
 
 class InvoiceDeleteView(UserIsAdminMixin, CheckedDeleteView):

--- a/barsys/views.py
+++ b/barsys/views.py
@@ -408,14 +408,35 @@ class InvoiceDetailView(UserIsAdminMixin, DetailView):
 class InvoiceResendView(UserIsAdminMixin, View):
     def get(self, request, pk):
         invoice = get_object_or_404(Invoice, pk=pk)
-        view_helpers.send_invoice_mails(request, [invoice], users_autolocked=[], send_dependant_notifications=True)
+        try:
+            conn = view_helpers.EmailConnectionWrapper(fake_sending_mails=False)
+        except Exception as e:
+            messages.error(request, "Could not connect to mail server: {}".format(e))
+            return redirect("admin_invoice_list")
+        if conn.send_message(view_helpers.generate_email_invoice(invoice)):
+            messages.success(request, "Invoice mail resent successfully.")
+        else:
+            messages.error(request, "Failed to resend invoice mail: {}".format(conn.last_error))
+        conn.close()
         return redirect("admin_invoice_list")
 
 
 class PaymentReminderSendView(UserIsAdminMixin, View):
     def get(self, request, pk):
         user = get_object_or_404(User, pk=pk)
-        view_helpers.send_reminder_mails(request, [user])
+        if user.account_balance() >= 0:
+            messages.warning(request, "Payment reminder not sent: {}'s account balance is not below 0.".format(user))
+            return redirect("admin_user_detail", pk=pk)
+        try:
+            conn = view_helpers.EmailConnectionWrapper(fake_sending_mails=False)
+        except Exception as e:
+            messages.error(request, "Could not connect to mail server: {}".format(e))
+            return redirect("admin_user_detail", pk=pk)
+        if conn.send_message(view_helpers.generate_email_payment_reminder(user)):
+            messages.success(request, "Payment reminder sent successfully.")
+        else:
+            messages.error(request, "Failed to send payment reminder: {}".format(conn.last_error))
+        conn.close()
         return redirect("admin_user_detail", pk=pk)
 
 
@@ -479,7 +500,7 @@ class InvoiceCreateView(UserIsAdminMixin, edit.FormView):
         view_helpers.create_invoices(
             self.request,
             users=form.cleaned_data["users"],
-            send_invoices=form.cleaned_data["send_invoices"],
+            send_mails=form.cleaned_data["send_invoices"],
             send_dependant_notifications=form.cleaned_data["send_dependant_notifications"],
             send_payment_reminders=form.cleaned_data["send_payment_reminders"],
             autolock_accounts=form.cleaned_data["autolock_accounts"],


### PR DESCRIPTION
view_helpers:
- Add EmailConnectionWrapper: wraps Django mail connection to enable unification of mail sending with create_invoices later.
- Extract HTML mail generation as helper functions
- Refactor send_invoice_mails() and send_reminder_mails() to use the wrapper; eliminate nested try/except in favor of bool checks
- send_invoice_mails() now requires users_autolocked and rolls back autolocks on mail failure or connection error
- Extract create_invoices() from InvoiceCreateView; tracks and reports auto-unlocks
- send_reminder_mails() skips users with balance >= 0, reports skipped count
- Set context["subject"] in all mail-sending paths and debug views

views / forms:
- PaymentForm: restrict user dropdown to self-paying users; block others on submit
- InvoiceCreateView: pre-select user via ?user=<pk> query param (get_initial)

UI:
- Invoice creation: Show filter box for user names (kind of a hack)
- User detail: "Create invoice" button (self-paying users only), payment reminder button (balance < 0 only), mail preview footer buttons
- Payment detail: always show "Generate invoice for user" button
- Invoice detail: mail preview footer button